### PR TITLE
chore: allow deprecated declarations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ endif ()
 
 find_package(autoware_cmake REQUIRED)
 autoware_package()
+add_compile_options(-Wno-deprecated-declarations)
 
 include(CheckLanguage)
 check_language(CUDA)


### PR DESCRIPTION
[NMSParameters](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/structnvinfer1_1_1plugin_1_1_n_m_s_parameters.html) and [IPluginV2DynamicExt](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_plugin_v2_dynamic_ext.html) are deprecated for incoming TensorRT 10.7 upgrade.